### PR TITLE
fix(journal): reject flag syntax in add positionals — silent data loss (v0.2.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agiterra/knowledge-tools",
-  "version": "0.2.4",
-  "description": "Knowledge vault primitives — association search, journal, vault indexing, vector search, sonnet filter.",
+  "version": "0.2.5",
+  "description": "Knowledge vault primitives \u2014 association search, journal, vault indexing, vector search, sonnet filter.",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/scripts/journal.py
+++ b/scripts/journal.py
@@ -563,6 +563,13 @@ if __name__ == '__main__':
         category = argv[1]
         summary = argv[2]
         context = argv[3]
+        # <category> <summary> <context> are positional; a flag landing in one
+        # of those slots means the caller used flag syntax — the flag strings
+        # would be stored literally and the real values dropped (silent data loss).
+        if any(v.startswith('--') for v in (category, summary, context)):
+            print('journal.py add: <category> <summary> <context> are positional; flags come after them')
+            print('Usage: journal.py add <category> <summary> <context> [--source X] [--tags a,b] [--refs 1,2]')
+            sys.exit(1)
         # Parse optional flags
         source = tags = refs = None
         i = 4
@@ -577,7 +584,9 @@ if __name__ == '__main__':
                 refs = argv[i + 1]
                 i += 2
             else:
-                i += 1
+                print(f'journal.py add: unrecognized argument: {argv[i]}')
+                print('Usage: journal.py add <category> <summary> <context> [--source X] [--tags a,b] [--refs 1,2]')
+                sys.exit(1)
         cmd_add(category, summary, context, source, tags, refs)
 
     elif cmd == 'get':


### PR DESCRIPTION
## Bug (reported by herald via wire, 2026-07-12)

`journal.py add` takes positional `<category> <summary> <context>`, but a caller using flag syntax (`--category X --summary Y --context Z`) got the flag strings stored **literally** as field values while the real content was silently dropped — exit 0, no error. This permanently corrupted herald's j:799 (a second entry, j:808, was caught same-day and repaired).

Reproduced at HEAD: `add --category ops --summary "real" --context "real"` → row `(--category, ops, --summary)`, content lost.

## Fix

- Reject any `--`-prefixed value in the three positional slots → usage + exit 1.
- The option loop's silent `else: i += 1` now also rejects unrecognized flags (`--tag` typos) and stray trailing bare args (unquoted context) instead of skipping them.

## Tested (no suite in repo; manual battery)

1. flag syntax → rejected, exit 1 ✓
2. plain positionals → stored ✓
3. positionals + `--source/--tags/--refs` → stored with options ✓
4. unknown flag `--tag` → rejected ✓
5. trailing bare arg → rejected ✓
DB verified clean after battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)